### PR TITLE
Adding EmulationStation-DE Settings page & Theme Manager

### DIFF
--- a/src/data/changelog.json
+++ b/src/data/changelog.json
@@ -26,7 +26,7 @@
   {
     "title": "Bug fixes & Small Features",
     "type": "STEAMOS",
-    "description": "- Fixed PS3 Pkg parser so it doesn't grab discs in the hdd<br/>- GyroDSU working at last.<br/>- Steam Shortcut path bulk update<br/>- Fix DOSBox-pure config directory<br/>- Fix Vita3K Launcher<br/>- Fix EmuDeck Compressor tool with rvz files<br/>- EasyRPG SRM parser<br/>- Recursive SRM parsers are back<br/>- Added ESDE 2.0 beta<br/>- CSO Format support for PPSSPP",
+    "description": "- Fixed PS3 Pkg parser so it doesn't grab discs in the hdd<br/>- GyroDSU working at last.<br/>- Steam Shortcut path bulk update<br/>- Fix DOSBox-pure config directory<br/>- Fix Vita3K Launcher<br/>- Fix EmuDeck Compressor tool with rvz files<br/>- EasyRPG SRM parser<br/>- Recursive SRM parsers are back<br/>- Added ESDE 2.0 beta<br/>- CSO Format support for PPSSPP<br/>- Added 'EmulationStation-DE Settings' page and theme manager",
     "image": "false"
   }
 ]


### PR DESCRIPTION
- Updated changelog.json

ToDo:
- Add informational page under "Quick actions" labeled "EmulationStation-DE Settings" describing:
  - Roms path, downloaded media path, themes path, and current theme
- Add vertical menu listing all available themes and display screenshots when theme is highlighted
- Add "Install" and "Uninstall" buttons automatically download/unpack the selected theme
  - Uninstall button disabled if not installed